### PR TITLE
Add "browser" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "react-ux-password-field",
   "version": "0.9.6",
   "main": "src/index.js",
+  "browser": "./lib/react-ux-password-field.js",
   "description": "A UX forward password field for react-js",
   "scripts": {
     "dev": "webpack --watch --port 9501 --colors",


### PR DESCRIPTION
My webpack build was failing without this. An alternative would be running this before publish: `babel src --out-dir lib` and `"main": "lib/index.js"`.
