### PR TITLE
fixes #15, manually resetting selectionStart/End on input element in Firefox

### DIFF
--- a/lib/react-ux-password-field.js
+++ b/lib/react-ux-password-field.js
@@ -178,12 +178,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	  handleChange: function handleChange(e) {
 	    e.preventDefault();
 
+	    var native_target = e.nativeEvent.target;
 	    var val = e.target.value;
 	    var score;
 
 	    this.setState({
 	      value: val,
-	      isValid: e.target.validity.valid
+	      isValid: e.target.validity.valid,
+	      selectionStart: native_target.selectionStart,
+	      selectionEnd: native_target.selectionEnd
 	    });
 
 	    if (this.props.toggleMask) {
@@ -305,6 +308,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	    var onChange = _props.onChange;
 
 	    var props = _objectWithoutProperties(_props, ['onChange']);
+
+	    // overcome problem with firefox resetting the input selection point
+	    var that = this;
+	    setTimeout(function () {
+	      if (!/Firefox/.test(navigator.userAgent)) return;
+	      var elem = that.refs[that.props.id].getDOMNode();
+	      elem.selectionStart = that.state.selectionStart;
+	      elem.selectionEnd = that.state.selectionEnd;
+	    }, 1);
 
 	    return React.createElement(
 	      'div',

--- a/lib/react-ux-password-field.js
+++ b/lib/react-ux-password-field.js
@@ -88,7 +88,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	    toggleMask: RP.bool,
 	    unMaskTime: RP.number,
 	    minLength: RP.number,
-	    strengthLang: RP.array
+	    strengthLang: RP.array,
+	    id: RP.string
 	  },
 
 	  /*==========  DEFAULTS  ==========*/
@@ -102,7 +103,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	      minScore: 0,
 	      toggleMask: true,
 	      unMaskTime: config.unMaskTime,
-	      strengthLang: config.strengthLang
+	      strengthLang: config.strengthLang,
+	      id: 'input'
 	    };
 	  },
 

--- a/src/index.js
+++ b/src/index.js
@@ -112,12 +112,15 @@ var InputPassword = React.createClass({
   handleChange(e) {
     e.preventDefault();
 
+    var native_target = e.nativeEvent.target;
     var val = e.target.value;
     var score;
 
     this.setState({
       value: val,
-      isValid: e.target.validity.valid
+      isValid: e.target.validity.valid,
+      selectionStart : native_target.selectionStart,
+      selectionEnd : native_target.selectionEnd,
     });
 
     if (this.props.toggleMask) {
@@ -229,6 +232,15 @@ var InputPassword = React.createClass({
 
     // allow onChange to be passed from parent and not override default prop
     var {onChange, ...props} = this.props;
+
+    // overcome problem with firefox resetting the input selection point
+    var that = this;
+    setTimeout(function() {
+      if (!/Firefox/.test(navigator.userAgent)) return;
+      var elem = that.refs[that.props.id].getDOMNode();
+      elem.selectionStart = that.state.selectionStart;
+      elem.selectionEnd = that.state.selectionEnd;
+    }, 1);
 
     return (
       <div

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,8 @@ var InputPassword = React.createClass({
     toggleMask: RP.bool,
     unMaskTime: RP.number,
     minLength: RP.number,
-    strengthLang:RP.array
+    strengthLang:RP.array,
+    id: RP.string,
   },
 
 
@@ -34,7 +35,8 @@ var InputPassword = React.createClass({
       minScore: 0,
       toggleMask: true,
       unMaskTime: config.unMaskTime,
-      strengthLang: config.strengthLang
+      strengthLang: config.strengthLang,
+      id: 'input'
     }
   },
 


### PR DESCRIPTION
I wasn't sure if I should update both lib/react-ux-password-field.js and src/index.js at the same time. I looked at other contributions and still couldn't tell. I can modify the PR if need be.

Before: 
![rupf-before](https://cloud.githubusercontent.com/assets/12034/9673970/a9635816-5278-11e5-80d9-ce282ff3abdf.gif)

After: 
![rupf-after](https://cloud.githubusercontent.com/assets/12034/9674013/3cdbd19a-5279-11e5-957c-2899f653e5b8.gif)

In the after video, I demonstrate that this fix allows Firefox users to continue typing one character after the other, delete characters, jump to a particular character and delete it.
