### PR TITLE
Move build-time npm packages to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,10 @@
     "nodejs": ">=0.11.x"
   },
   "dependencies": {
+    "lodash.debounce": "^3.1.1",
+    "react": ">=0.13.0"
+  },
+  "devDependencies": {
     "autoprefixer-core": "^6.0.1",
     "babel": "^5.8.23",
     "babel-core": "^5.8.25",
@@ -49,10 +53,9 @@
     "file-loader": "^0.8.4",
     "gh-pages-deploy": "^0.3.0",
     "jsx-loader": "^0.13.2",
-    "lodash.debounce": "^3.1.1",
+    "jest-cli": "0.5.10",
     "normalize.css": "^3.0.3",
     "postcss-loader": "^0.6.0",
-    "react": ">=0.13.0",
     "root-require": "^0.3.1",
     "sass-loader": "^3.0.0",
     "script-loader": "^0.6.1",
@@ -60,9 +63,6 @@
     "url-loader": "^0.5.6",
     "webpack": "^1.12.2",
     "webpack-dev-server": "^1.12.1"
-  },
-  "devDependencies": {
-    "jest-cli": "0.5.10"
   },
   "gh-pages-deploy": {
     "staticpath": "demo",


### PR DESCRIPTION
Fixes: https://github.com/seethroughtrees/react-ux-password-field/issues/33

I don't think this breaks any of the existing scripts, but it would probably be a good idea to double check. 
## The Context

The only run-time packages that the src/index.js file uses is 'react' and 'lodash.debounce'. Everything else can be installed as a devDependency.

Moving build-time packages like `webpack`, `*-loaders`, and `babel-*` helps reduce the cruft for users that want to `npm shrinkwrap`.
## This PR
- Moves the following packages from `dependencies` to `devDependencies`
  - `autoprefixer-core`
  - `babel`
  - `babel-core`
  - `babel-jest`
  - `babel-loader`
  - `css-loader`
  - `csswring`
  - `extract-text-webpack-plugin`
  - `file-loader`
  - `gh-pages-deploy`
  - `jsx-loader`
  - `normalize.css`
  - `postcss-loader`
  - `root-require`
  - `sass-loader`
  - `script-loader`
  - `style-loader`
  - `url-loader`
  - `webpack`
  - `webpack-dev-server`
