### PR TITLE
Allow direct import without using a fully-qualified name

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-ux-password-field",
   "version": "0.9.10",
   "license": "MIT",
-  "main": "src/index.js",
+  "main": "lib/react-ux-password-field.js",
   "browser": "./lib/react-ux-password-field.js",
   "description": "A UX forward password field for react-js",
   "scripts": {


### PR DESCRIPTION
All credit goes to @ahoym for discovering and fixing this, as well as for the following problem description:

Files that used the `react-ux-password-field` had to directly grab the component from the `lib/react-ux-password-field.js` file since otherwise their tests would unexpectedly fail.

This meant imports had to be written like:

``` js
import InputPassword from 'react-ux-password-field/lib/react-ux-password-field';
```

After the change in  57816ba, we no longer need to do this and can:

``` js
import InputPassword from 'react-ux-password-field';
```
